### PR TITLE
[TASK-1] Polish the local model loading overlay

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -4585,7 +4585,7 @@ async function ensurePipeline(modelId, overlayTitle, modeKey) {
     updatePerformancePanel(snapshot);
     return pipeline;
   } finally {
-    hideProgressOverlay();
+    await hideProgressOverlay();
   }
 }
 
@@ -4596,7 +4596,7 @@ async function ensureRunPipeline() {
     : (state.uiMode === 'translate' ? 'translate' : 'run');
   setRunLoading(true);
   try {
-    return await ensurePipeline(modelId, 'Loading Model', modeKey);
+    return await ensurePipeline(modelId, 'Preparing Local Model', modeKey);
   } finally {
     setRunLoading(false);
   }
@@ -4607,7 +4607,7 @@ async function ensureDiffusionPipeline() {
   state.diffusionLoading = true;
   updateStatusIndicator();
   try {
-    return await ensurePipeline(modelId, 'Loading Model', 'diffusion');
+    return await ensurePipeline(modelId, 'Preparing Local Model', 'diffusion');
   } finally {
     state.diffusionLoading = false;
     updateStatusIndicator();
@@ -4734,7 +4734,7 @@ async function ensureEnergyPipeline() {
   state.energyLoading = true;
   updateStatusIndicator();
   try {
-    return await ensurePipeline(modelId, 'Loading Model', 'energy');
+    return await ensurePipeline(modelId, 'Preparing Local Model', 'energy');
   } finally {
     state.energyLoading = false;
     updateStatusIndicator();

--- a/demo/index.html
+++ b/demo/index.html
@@ -1031,10 +1031,14 @@
     <!-- Progress Dialog -->
     <div class="modal-overlay progress-overlay" id="progress-overlay" hidden>
       <div class="modal-content progress-content" role="dialog" aria-modal="true" aria-labelledby="progress-title">
-        <h3 class="modal-title progress-title" id="progress-title">Loading Model</h3>
+        <div class="progress-heading">
+          <h3 class="modal-title progress-title" id="progress-title">Preparing Local Model</h3>
+          <div class="progress-model-label type-caption">Model</div>
+          <p id="progress-model" class="progress-model type-caption"></p>
+        </div>
         <div class="progress-phases" id="progress-phases">
           <div class="progress-phase-row" data-phase="storage">
-            <span class="progress-phase-label">Reading</span>
+            <span class="progress-phase-label">Local files</span>
             <div class="progress">
               <div class="progress-fill"></div>
             </div>
@@ -1042,7 +1046,7 @@
           </div>
           <span id="progress-shard" class="progress-shard type-caption"></span>
           <div class="progress-phase-row" data-phase="gpu">
-            <span class="progress-phase-label">GPU Upload</span>
+            <span class="progress-phase-label">GPU setup</span>
             <div class="progress">
               <div class="progress-fill"></div>
             </div>

--- a/demo/ui/progress.d.ts
+++ b/demo/ui/progress.d.ts
@@ -1,4 +1,9 @@
 export function showProgressOverlay(title?: string): void;
-export function hideProgressOverlay(): void;
+export function hideProgressOverlay(): Promise<void>;
 export function setProgressPhase(phase: string, percent: number, label?: string): void;
-export function updateProgressFromLoader(info?: { stage?: string; progress?: number; message?: string } | null): void;
+export function updateProgressFromLoader(info?: {
+  stage?: string;
+  progress?: number;
+  percent?: number;
+  message?: string;
+} | null): void;

--- a/demo/ui/progress.js
+++ b/demo/ui/progress.js
@@ -1,21 +1,46 @@
 import { $, setText } from './dom.js';
 import { clampPercent } from './ui.js';
 
+const PROGRESS_COMPLETE_DWELL_MS = 180;
+const STORAGE_STAGE_DETAILS = Object.freeze({
+  manifest: 'Reading local model files.',
+  shards: 'Reading local model files.',
+  tensors: 'Preparing model in memory.',
+});
+const GPU_STAGE_DETAILS = Object.freeze({
+  layers: 'Preparing GPU resources.',
+  gpu_transfer: 'Preparing GPU resources.',
+  pipeline: 'Almost ready.',
+  complete: 'Almost ready.',
+});
+
 export function showProgressOverlay(title, modelId) {
   const overlay = $('progress-overlay');
   const titleEl = $('progress-title');
-  const label = modelId ? `${title || 'Loading Model'} — ${modelId}` : (title || 'Loading Model');
+  const modelEl = $('progress-model');
+  const label = title || 'Preparing Local Model';
   if (titleEl) titleEl.textContent = label;
+  if (modelEl) modelEl.textContent = modelId || '';
+  if (overlay) delete overlay.dataset.completedAtMs;
   setProgressPhase('storage', 0, '--');
   setProgressPhase('gpu', 0, '--');
-  setProgressDetail('');
+  setProgressDetail('Reading local model files.');
   setProgressShard(null, null);
   if (overlay) overlay.hidden = false;
 }
 
-export function hideProgressOverlay() {
+export async function hideProgressOverlay() {
   const overlay = $('progress-overlay');
-  if (overlay) overlay.hidden = true;
+  if (!overlay) return;
+  const completedAtMs = Number(overlay.dataset.completedAtMs);
+  if (Number.isFinite(completedAtMs) && completedAtMs > 0) {
+    const elapsedMs = Date.now() - completedAtMs;
+    const remainingMs = PROGRESS_COMPLETE_DWELL_MS - elapsedMs;
+    if (remainingMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, remainingMs));
+    }
+  }
+  overlay.hidden = true;
 }
 
 export function setProgressPhase(phase, percent, label) {
@@ -44,12 +69,21 @@ export function setProgressShard(shard, totalShards) {
 export function updateProgressFromLoader(info) {
   if (!info) return;
   const stage = info.stage || '';
-  const percent = Number.isFinite(info.progress) ? info.progress * 100 : 0;
+  const normalizedProgress = Number.isFinite(info.progress)
+    ? info.progress * 100
+    : (Number.isFinite(info.percent) ? info.percent : 0);
+  const percent = clampPercent(normalizedProgress);
   const label = `${Math.round(clampPercent(percent))}%`;
+  const isGpuPhase = stage === 'layers' || stage === 'gpu_transfer' || stage === 'complete' || stage === 'pipeline';
 
-  if (stage === 'layers' || stage === 'gpu_transfer' || stage === 'complete' || stage === 'pipeline') {
+  if (isGpuPhase) {
+    setProgressPhase('storage', 100, '100%');
     setProgressPhase('gpu', percent, label);
     setProgressShard(null, null);
+    if (stage === 'complete') {
+      const overlay = $('progress-overlay');
+      if (overlay) overlay.dataset.completedAtMs = String(Date.now());
+    }
   } else {
     setProgressPhase('storage', percent, label);
     if (stage === 'shards' && info.shard != null && info.totalShards != null) {
@@ -57,5 +91,10 @@ export function updateProgressFromLoader(info) {
     }
   }
 
-  setProgressDetail(info.message || '');
+  setProgressDetail(
+    STORAGE_STAGE_DETAILS[stage]
+      || GPU_STAGE_DETAILS[stage]
+      || info.message
+      || ''
+  );
 }

--- a/demo/ui/styles/main.css
+++ b/demo/ui/styles/main.css
@@ -2074,50 +2074,99 @@
 
     /* Overlays */
     .progress-content {
-      width: 400px;
-      max-width: 90%;
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-lg);
+      width: min(560px, calc(100vw - 48px));
+      max-width: 100%;
+      padding: 24px 28px 22px;
+      box-sizing: border-box;
+      border: var(--border-md) solid var(--fg);
+      background: var(--bg);
     }
 
     /* Progress Phases */
+    .progress-heading {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 6px;
+    }
+
     .progress-title {
       text-align: center;
-      margin-bottom: var(--space-md);
+      margin: 0;
+      line-height: 1.35;
+      text-wrap: balance;
+    }
+
+    .progress-model-label {
+      margin: 2px 0 0;
+      opacity: 0.76;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .progress-model {
+      margin: 0;
+      max-width: min(100%, 42ch);
+      padding: 6px 12px;
+      border: var(--border-sm) dotted color-mix(in srgb, var(--fg) 44%, transparent);
+      background: color-mix(in srgb, var(--bg-contrast) 82%, var(--bg));
+      font-family: var(--demo-value-family);
+      font-size: calc(var(--demo-value-size) + 1px);
+      font-weight: 500;
+      line-height: 1.55;
+      letter-spacing: 0;
+      text-transform: none;
+      text-align: center;
+      overflow-wrap: anywhere;
+      color: color-mix(in srgb, var(--fg) 90%, var(--bg));
+      opacity: 1;
     }
 
     .progress-phases {
       display: flex;
       flex-direction: column;
-      gap: var(--space-sm);
+      gap: var(--space-md);
+      margin-top: 2px;
     }
 
     .progress-phase-row {
       display: grid;
-      grid-template-columns: 80px 1fr 60px;
-      gap: var(--space-sm);
+      grid-template-columns: 104px minmax(0, 1fr) 44px;
+      gap: 14px;
       align-items: center;
+    }
+
+    .progress-phase-label {
+      opacity: 0.9;
     }
 
     .progress-phase-value {
       text-align: right;
+      font-variant-numeric: tabular-nums;
+      opacity: 0.9;
     }
 
     .progress-shard {
       text-align: right;
       opacity: 0.6;
       min-height: 1em;
-      margin-top: -2px;
+      margin-top: -4px;
     }
 
     .progress-detail {
       text-align: center;
-      margin-top: var(--space-sm);
-      margin-bottom: 0;
-      opacity: 0.7;
+      margin: 0 auto;
+      opacity: 0.58;
       min-height: 1.2em;
+      line-height: 1.65;
+      max-width: 30ch;
     }
 
     .progress-sm {
-      height: 6px;
+      height: 8px;
     }
 
     /* Inline download progress on quick model cards */
@@ -2146,7 +2195,11 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      padding: 24px;
       z-index: 100;
+      background: color-mix(in srgb, var(--fg) 18%, transparent);
+      backdrop-filter: blur(1.5px);
+      -webkit-backdrop-filter: blur(1.5px);
     }
 
     .modal-overlay[hidden] {


### PR DESCRIPTION
## Summary

This PR polishes the local model loading overlay in the Doppler demo.

It improves the visual hierarchy and readability of the modal, fixes progress-bar updates during local model preparation, and makes the completion flow easier to perceive during real use.

## What Changed

- updated the overlay title from `Loading Model` to `Preparing Local Model`
- separated the model ID into its own metadata block
- refined spacing, alignment, and progress-row composition
- changed the overlay to appear as a modal over the existing page with a dimmed backdrop
- mapped internal loading stages to clearer user-facing detail copy
- fixed progress handling so the bars respond to `percent`-based progress events
- ensured `Local files` completes once GPU preparation begins
- added a short completion dwell so the final `100%` state is visible before the modal closes

BEFORE
<img width="513" height="236" alt="Screenshot 2026-03-16 at 12 27 39 PM" src="https://github.com/user-attachments/assets/31900895-e040-44ff-904e-1f8e8f7b3f60" />

AFTER
<img width="1959" height="986" alt="Screenshot 2026-03-16 at 1 09 37 PM" src="https://github.com/user-attachments/assets/08997b60-a1f2-4eb1-9dd1-608a1cd94cca" />

## Files Touched

- `demo/demo.js`
- `demo/index.html`
- `demo/ui/progress.d.ts`
- `demo/ui/progress.js`
- `demo/ui/styles/main.css`

## Testing Instructions

1. Start the local static server from the Doppler repo root:

   ```bash
   cd /Users/haileyrobledo/Git/deco/doppler
   python3 -m http.server 8080
   ```

2. Open the demo in the browser:
   - `http://localhost:8080/demo/`

3. Load a model that already exists in local storage / OPFS.

4. Verify the overlay:
   - appears over the existing page instead of on a blank screen
   - dims the background enough to make the modal stand out
   - shows the model name in a readable metadata block
   - displays filling progress bars for both phases
   - shows `Local files` as complete once `GPU setup` is underway
   - remains visible briefly when progress reaches `100%`

5. Check the experience at:
   - desktop width
   - tablet width
   - phone width

The issue was that I wrapped the Markdown in an outer code fence, which prevents the inner fenced bash block from copying/rendering correctly.



