### PR TITLE
[TASK-2] Polish text mode layout and panel semantics

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -4535,7 +4535,8 @@ function syncRunControls() {
     ? 'embedding'
     : (state.uiMode === 'translate' ? 'translate' : 'run');
   const hasCompatibleModel = Number.isFinite(availability[modeKey]) && availability[modeKey] > 0;
-  const disabled = state.runGenerating || state.runLoading || state.compareGenerating || state.compareLoading;
+  const isRunning = state.runGenerating;
+  const disabled = isRunning || state.runLoading || state.compareGenerating || state.compareLoading;
   if (runPrompt) runPrompt.disabled = disabled;
   if (runGenerate) runGenerate.disabled = disabled || !hasCompatibleModel;
   if (runClear) runClear.disabled = disabled;
@@ -4547,7 +4548,8 @@ function syncRunControls() {
   if (topPInput) topPInput.disabled = disabled;
   if (topKInput) topKInput.disabled = disabled;
   if (maxTokensInput) maxTokensInput.disabled = disabled;
-  if (runStop) setHidden(runStop, !state.runGenerating);
+  if (runGenerate) setHidden(runGenerate, isRunning);
+  if (runStop) setHidden(runStop, !isRunning);
 }
 
 function setRunGenerating(isGenerating) {
@@ -6581,10 +6583,14 @@ function setAppBootstrapVisible(visible, message = null) {
 }
 
 function syncMobileAdvanced() {
-  const isDesktop = window.matchMedia('(min-width: 778px)').matches;
+  const isDesktop = window.matchMedia('(min-width: 1025px)').matches;
   document.querySelectorAll('details.mobile-advanced').forEach((el) => {
     if (isDesktop) {
-      el.setAttribute('open', '');
+      if (el.id === 'run-sampling-controls') {
+        el.removeAttribute('open');
+      } else {
+        el.setAttribute('open', '');
+      }
     } else {
       el.removeAttribute('open');
     }
@@ -6602,7 +6608,7 @@ async function init() {
   try {
     ensurePrimaryModeControlStack();
     syncMobileAdvanced();
-    window.matchMedia('(min-width: 778px)').addEventListener('change', syncMobileAdvanced);
+    window.matchMedia('(min-width: 1025px)').addEventListener('change', syncMobileAdvanced);
     const deepLinkState = readDeepLinkStateFromLocation();
     state.surface = normalizeSurface(deepLinkState.surface, state.surface || 'demo');
     syncSurfaceUI(state.surface);

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -3265,10 +3265,19 @@ function getModelAvailability() {
 
 function setEmptyNotice(scope, message) {
   const notice = $(`${scope}-empty-notice`);
+  const kicker = $(`${scope}-empty-notice-kicker`);
   const text = $(`${scope}-empty-notice-text`);
-  const normalized = typeof message === 'string' ? message.trim() : '';
-  setHidden(notice, normalized.length === 0);
-  setText(text, normalized);
+  const detail = $(`${scope}-empty-notice-detail`);
+  const normalized = message && typeof message === 'object'
+    ? message
+    : null;
+  const title = typeof normalized?.title === 'string' ? normalized.title.trim() : '';
+  const support = typeof normalized?.detail === 'string' ? normalized.detail.trim() : '';
+  const kickerText = typeof normalized?.kicker === 'string' ? normalized.kicker.trim() : 'Setup required';
+  setHidden(notice, title.length === 0);
+  setText(kicker, title ? kickerText : '');
+  setText(text, title);
+  setText(detail, support);
 }
 
 function setEmptyNoticeAction(scope, quickModelEntry) {
@@ -3284,43 +3293,104 @@ function setEmptyNoticeAction(scope, quickModelEntry) {
     if (isBusy) {
       const progress = resolveDownloadProgressForModel(quickModelEntry.modelId);
       const pct = progress?.percent;
-      button.textContent = Number.isFinite(pct) ? `Fetching ${Math.round(pct)}%` : 'Fetching...';
+      button.textContent = Number.isFinite(pct) ? `Importing ${Math.round(pct)}%` : 'Importing...';
     } else {
-      button.textContent = `Download ${quickModelEntry.label}`;
+      button.textContent = 'Import recommended model';
     }
+    button.title = `Import ${quickModelEntry.label}`;
     button.disabled = isBusy || (hasBusyImport && !isBusy);
     return;
   }
 
   button.dataset.noticeAction = 'models';
   delete button.dataset.quickModelId;
-  button.textContent = 'Go to Models';
+  button.textContent = 'Browse models';
+  button.title = 'Browse imported and available models';
   button.disabled = hasBusyImport;
+}
+
+function createMissingModelNotice(title, detail, kicker = 'Setup required') {
+  return {
+    kicker,
+    title,
+    detail,
+  };
 }
 
 function getMissingModelMessage(mode, availability, quickModelEntry) {
   if (mode === 'energy') {
-    return '';
+    return null;
   }
   const total = Number.isFinite(availability?.total) ? availability.total : 0;
   const hasQuickSuggestion = !!(quickModelEntry && typeof quickModelEntry.modelId === 'string' && quickModelEntry.modelId.length > 0);
   if (total <= 0) {
+    if (mode === 'embedding') {
+      return hasQuickSuggestion
+        ? createMissingModelNotice(
+          'Import an embedding model to get started.',
+          'Import the recommended model, or open Models to choose a different one.'
+        )
+        : createMissingModelNotice(
+          'Import an embedding model to get started.',
+          'Open Models to choose one that supports similarity and retrieval.'
+        );
+    }
+    if (mode === 'translate') {
+      return hasQuickSuggestion
+        ? createMissingModelNotice(
+          'Import a translation model to get started.',
+          'Import the recommended model, or open Models to choose a different one.'
+        )
+        : createMissingModelNotice(
+          'Import a translation model to get started.',
+          'Open Models to choose one that supports translation.'
+        );
+    }
+    if (mode === 'diffusion') {
+      return hasQuickSuggestion
+        ? createMissingModelNotice(
+          'Import an image model to get started.',
+          'Import the recommended model, or open Models to choose a different one.'
+        )
+        : createMissingModelNotice(
+          'Import an image model to get started.',
+          'Open Models to choose one that supports diffusion.'
+        );
+    }
     return hasQuickSuggestion
-      ? 'Import a model that supports this mode to continue.'
-      : 'No models found in OPFS. Import a model from the Models tab.';
+      ? createMissingModelNotice(
+        'Import a text model to get started.',
+        'Import the recommended model, or open Models to choose a different one.'
+      )
+      : createMissingModelNotice(
+        'Import a text model to get started.',
+        'Open Models to choose one that supports text generation.'
+      );
   }
   const compatible = Number.isFinite(availability?.[mode]) ? availability[mode] : 0;
-  if (compatible > 0) return '';
+  if (compatible > 0) return null;
   if (mode === 'embedding') {
-    return 'No embedding model available in OPFS for this mode.';
+    return createMissingModelNotice(
+      'This mode needs an embedding model.',
+      'Your imported models do not support embedding yet. Import a compatible model to continue.'
+    );
   }
   if (mode === 'translate') {
-    return 'No text translation model available in OPFS for this mode.';
+    return createMissingModelNotice(
+      'This mode needs a translation model.',
+      'Your imported models do not support translation yet. Import a compatible model to continue.'
+    );
   }
   if (mode === 'diffusion') {
-    return 'No diffusion model available in OPFS for this mode.';
+    return createMissingModelNotice(
+      'This mode needs an image model.',
+      'Your imported models do not support diffusion yet. Import a compatible model to continue.'
+    );
   }
-  return 'No text model available in OPFS for this mode.';
+  return createMissingModelNotice(
+    'This mode needs a text model.',
+    'Your imported models do not support text generation yet. Import a compatible model to continue.'
+  );
 }
 
 function setQuickModelStatus(message) {
@@ -3796,11 +3866,11 @@ function updateModelEmptyStates() {
 
   const diffusionRun = $('diffusion-run-btn');
   if (diffusionRun) {
-    diffusionRun.disabled = state.diffusionGenerating || state.diffusionLoading || diffusionMessage.length > 0;
+    diffusionRun.disabled = state.diffusionGenerating || state.diffusionLoading || !!diffusionMessage;
   }
   const energyRun = $('energy-run-btn');
   if (energyRun) {
-    energyRun.disabled = state.energyGenerating || state.energyLoading || energyMessage.length > 0;
+    energyRun.disabled = state.energyGenerating || state.energyLoading || !!energyMessage;
   }
   syncRunControls();
 }

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -3127,16 +3127,18 @@ function ensurePrimaryModeControlStack() {
   const panelGrid = $('panel-grid');
   if (!panelGrid) return;
 
+  const primaryStack = panelGrid.querySelector('.panel-stack-primary');
   const railStack = panelGrid.querySelector('.panel-stack-rail');
-  if (!railStack) return;
+  const insertionPoint = primaryStack || railStack;
+  if (!insertionPoint) return;
 
   let controlsStack = panelGrid.querySelector('.panel-stack-controls');
   if (!controlsStack) {
     controlsStack = document.createElement('div');
     controlsStack.className = 'panel-stack panel-stack-controls';
     controlsStack.dataset.modes = 'run translate embedding diffusion energy';
-    panelGrid.insertBefore(controlsStack, railStack);
   }
+  panelGrid.insertBefore(controlsStack, insertionPoint);
 
   const controlSectionSelectors = [
     '.run-controls-panel',

--- a/demo/index.html
+++ b/demo/index.html
@@ -853,7 +853,7 @@
                   <label class="type-caption" for="run-prompt" id="run-prompt-label">Prompt</label>
                   <button class="btn btn-small" id="run-prompt-shuffle" type="button">Shuffle</button>
                 </div>
-                <textarea id="run-prompt" class="w-full" rows="6" placeholder="Ask a question or provide a prompt..."></textarea>
+                <textarea id="run-prompt" class="w-full" rows="7" placeholder="Ask a question or provide a prompt..."></textarea>
               </div>
               <div class="panel-subsection" id="run-embedding-docs" hidden>
                 <div class="playground-label-row">
@@ -863,7 +863,7 @@
                 <div id="run-embedding-docs-list" class="embedding-doc-list"></div>
               </div>
               <details class="mobile-advanced" id="run-sampling-controls">
-                <summary class="mobile-advanced-toggle type-caption">Advanced</summary>
+                <summary class="mobile-advanced-toggle type-caption">Generation settings</summary>
                 <div class="playground-row">
                   <div class="playground-field">
                     <label class="type-caption" for="temperature-input">Temperature</label>
@@ -890,7 +890,7 @@
                 </div>
                 <div class="playground-field">
                   <label
-                    class="type-caption"
+                    class="check-field type-caption"
                     for="run-reset-kv-toggle"
                     title="Clears KV cache before Generate so each run is independent."
                     aria-label="Reset context each run. Clears KV cache before Generate so each run is independent."

--- a/demo/index.html
+++ b/demo/index.html
@@ -80,10 +80,6 @@
           <div class="panel-stack panel-stack-primary">
             <section class="panel run-panel" data-modes="run translate embedding">
               <h2 class="type-label" id="run-panel-title">Text Generation</h2>
-              <div id="run-empty-notice" class="model-empty-notice" hidden>
-                <span id="run-empty-notice-text" class="type-caption"></span>
-                <button id="run-empty-notice-btn" class="btn btn-primary btn-small" type="button">Go to Models</button>
-              </div>
               <div class="primary-stack">
                 <div class="playground-output">
                   <div class="type-caption">Output</div>
@@ -360,8 +356,12 @@
             <section class="panel diffusion-panel" data-modes="diffusion">
               <h2 class="type-label">Image Generation</h2>
               <div id="diffusion-empty-notice" class="model-empty-notice" hidden>
-                <span id="diffusion-empty-notice-text" class="type-caption"></span>
-                <button id="diffusion-empty-notice-btn" class="btn btn-primary btn-small" type="button">Go to Models</button>
+                <div class="model-empty-notice-copy">
+                  <div id="diffusion-empty-notice-kicker" class="model-empty-notice-kicker">Setup required</div>
+                  <div id="diffusion-empty-notice-text" class="model-empty-notice-title"></div>
+                  <div id="diffusion-empty-notice-detail" class="model-empty-notice-detail"></div>
+                </div>
+                <button id="diffusion-empty-notice-btn" class="btn btn-small model-empty-notice-action" type="button">Browse models</button>
               </div>
               <div class="primary-stack">
                 <div class="playground-output">
@@ -375,8 +375,12 @@
             <section class="panel energy-panel keyvalue-panel" data-modes="energy">
               <h2 class="type-label">Energy Optimization</h2>
               <div id="energy-empty-notice" class="model-empty-notice" hidden>
-                <span id="energy-empty-notice-text" class="type-caption"></span>
-                <button id="energy-empty-notice-btn" class="btn btn-primary btn-small" type="button">Go to Models</button>
+                <div class="model-empty-notice-copy">
+                  <div id="energy-empty-notice-kicker" class="model-empty-notice-kicker">Setup required</div>
+                  <div id="energy-empty-notice-text" class="model-empty-notice-title"></div>
+                  <div id="energy-empty-notice-detail" class="model-empty-notice-detail"></div>
+                </div>
+                <button id="energy-empty-notice-btn" class="btn btn-small model-empty-notice-action" type="button">Browse models</button>
               </div>
               <div id="energy-output-status" class="type-caption">Idle</div>
               <div class="panel-subsection" data-energy-problem="quintel">
@@ -433,8 +437,12 @@
                 </div>
               </div>
               <div id="diagnostics-empty-notice" class="model-empty-notice" hidden>
-                <span id="diagnostics-empty-notice-text" class="type-caption"></span>
-                <button id="diagnostics-empty-notice-btn" class="btn btn-primary btn-small" type="button">Go to Models</button>
+                <div class="model-empty-notice-copy">
+                  <div id="diagnostics-empty-notice-kicker" class="model-empty-notice-kicker">Setup required</div>
+                  <div id="diagnostics-empty-notice-text" class="model-empty-notice-title"></div>
+                  <div id="diagnostics-empty-notice-detail" class="model-empty-notice-detail"></div>
+                </div>
+                <button id="diagnostics-empty-notice-btn" class="btn btn-small model-empty-notice-action" type="button">Browse models</button>
               </div>
               <div class="type-caption diagnostics-summary" id="diagnostics-summary"></div>
               <div class="diagnostics-actions">
@@ -805,7 +813,14 @@
             <section class="panel run-controls-panel" data-modes="run translate embedding">
               <div class="panel-title-row">
                 <h2 class="type-label" id="run-controls-title">Run Controls</h2>
-                <button class="btn btn-small" id="run-prompt-shuffle" type="button">Shuffle</button>
+              </div>
+              <div id="run-empty-notice" class="model-empty-notice" hidden>
+                <div class="model-empty-notice-copy">
+                  <div id="run-empty-notice-kicker" class="model-empty-notice-kicker">Setup required</div>
+                  <div id="run-empty-notice-text" class="model-empty-notice-title"></div>
+                  <div id="run-empty-notice-detail" class="model-empty-notice-detail"></div>
+                </div>
+                <button id="run-empty-notice-btn" class="btn btn-small model-empty-notice-action" type="button">Browse models</button>
               </div>
               <div class="panel-subsection" id="translate-controls" hidden>
                 <div class="translate-control-banner">
@@ -836,6 +851,7 @@
               <div class="playground-field">
                 <div class="playground-label-row">
                   <label class="type-caption" for="run-prompt" id="run-prompt-label">Prompt</label>
+                  <button class="btn btn-small" id="run-prompt-shuffle" type="button">Shuffle</button>
                 </div>
                 <textarea id="run-prompt" class="w-full" rows="6" placeholder="Ask a question or provide a prompt..."></textarea>
               </div>

--- a/demo/ui/styles/main.css
+++ b/demo/ui/styles/main.css
@@ -530,9 +530,30 @@
       display: none;
     }
 
-    /* Desktop: hide the toggle — open attribute is set by JS */
+    /* Desktop: hide the toggle unless a section opts into desktop collapsing. */
     details.mobile-advanced > summary {
       display: none;
+    }
+
+    #run-sampling-controls > summary {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      cursor: pointer;
+      user-select: none;
+      padding: 6px 0 0;
+      border-top: var(--border-sm) dotted color-mix(in srgb, var(--fg) 24%, transparent);
+    }
+
+    #run-sampling-controls > summary::after {
+      content: '+';
+      font-family: var(--demo-label-family);
+      font-size: var(--demo-label-size);
+      font-weight: 700;
+    }
+
+    #run-sampling-controls[open] > summary::after {
+      content: '-';
     }
 
     .panel-title-row {
@@ -638,8 +659,9 @@
     .run-controls-panel .model-empty-notice {
       grid-template-columns: minmax(0, 1fr);
       align-items: flex-start;
-      gap: var(--space-sm);
-      margin-bottom: var(--space-xs);
+      gap: 6px;
+      padding: 12px 14px 12px 16px;
+      margin-bottom: var(--space-sm);
     }
 
     .run-controls-panel .model-empty-notice-title {
@@ -653,6 +675,20 @@
 
     .run-controls-panel .model-empty-notice-action {
       justify-self: start;
+    }
+
+    .run-controls-panel .model-empty-notice-copy {
+      gap: 2px;
+    }
+
+    .run-controls-panel .model-empty-notice-title {
+      font-size: 13px;
+      line-height: 1.28;
+    }
+
+    .run-controls-panel .model-empty-notice-detail {
+      font-size: 11px;
+      line-height: 1.4;
     }
 
     #app[data-mode="run"] .run-controls-panel,
@@ -805,6 +841,34 @@
       gap: var(--space-xs);
     }
 
+    .run-controls-panel {
+      gap: var(--space-md);
+    }
+
+    .run-controls-panel .playground-field {
+      gap: 6px;
+    }
+
+    .run-controls-panel #run-prompt {
+      min-height: 132px;
+    }
+
+    .run-controls-panel #run-sampling-controls[open] {
+      padding-top: 2px;
+    }
+
+    .run-controls-panel #run-sampling-controls .playground-row:first-of-type {
+      margin-top: var(--space-xs);
+    }
+
+    .run-controls-panel #run-sampling-controls .playground-row + .playground-row {
+      margin-top: var(--space-xs);
+    }
+
+    .run-controls-panel #run-sampling-controls > .playground-field:last-child {
+      margin-top: var(--space-xs);
+    }
+
     .playground-label-row {
       display: flex;
       align-items: center;
@@ -838,14 +902,11 @@
       display: grid;
       grid-template-columns: repeat(2, minmax(0, 1fr));
       gap: var(--space-sm);
+      margin-top: var(--space-sm);
     }
 
     .run-controls-panel .playground-actions .btn {
       width: 100%;
-    }
-
-    .run-controls-panel #run-stop-btn {
-      grid-column: 1 / -1;
     }
 
     .embedding-doc-list {
@@ -2162,6 +2223,10 @@
       gap: 4px;
     }
 
+    .live-panel .run-log-row {
+      grid-template-columns: 40px 0.72fr 1.18fr 1.18fr 0.66fr;
+    }
+
     .keyvalue-panel .pulse-subheader {
       margin: 0;
       padding-bottom: 3px;
@@ -2213,11 +2278,12 @@
 
     .live-panel .run-log-header > span {
       font-family: var(--demo-label-family);
-      font-size: var(--demo-label-size);
+      font-size: 9px;
       font-weight: 700;
-      letter-spacing: var(--demo-label-tracking);
+      letter-spacing: 0.05em;
       text-transform: uppercase;
       opacity: 0.9;
+      white-space: nowrap;
     }
 
     /* Overlays */

--- a/demo/ui/styles/main.css
+++ b/demo/ui/styles/main.css
@@ -535,13 +535,24 @@
       display: none;
     }
 
+    #run-sampling-controls > summary,
+    .keyvalue-panel .pulse-subheader {
+      margin: 0;
+      font-family: var(--demo-label-family);
+      font-size: var(--demo-label-size);
+      font-weight: 700;
+      letter-spacing: var(--demo-label-tracking);
+      text-transform: uppercase;
+      line-height: var(--demo-label-line-height);
+    }
+
     #run-sampling-controls > summary {
       display: flex;
       align-items: center;
       justify-content: space-between;
       cursor: pointer;
       user-select: none;
-      padding: 6px 0 0;
+      padding: 8px 0 4px;
       border-top: var(--border-sm) dotted color-mix(in srgb, var(--fg) 24%, transparent);
     }
 
@@ -550,6 +561,8 @@
       font-family: var(--demo-label-family);
       font-size: var(--demo-label-size);
       font-weight: 700;
+      line-height: 1;
+      opacity: 0.9;
     }
 
     #run-sampling-controls[open] > summary::after {
@@ -1562,7 +1575,6 @@
 
     #run-output-status {
       padding-top: 6px;
-      border-top: var(--border-sm) dotted color-mix(in srgb, var(--fg) 26%, transparent);
       color: color-mix(in srgb, var(--fg) 74%, transparent);
       line-height: 1.2;
     }
@@ -2228,15 +2240,8 @@
     }
 
     .keyvalue-panel .pulse-subheader {
-      margin: 0;
       padding-bottom: 3px;
       border-bottom: var(--border-sm) dotted var(--fg);
-      font-family: var(--demo-label-family);
-      font-size: var(--demo-label-size);
-      font-weight: 700;
-      letter-spacing: var(--demo-label-tracking);
-      text-transform: uppercase;
-      line-height: var(--demo-label-line-height);
     }
 
     .keyvalue-panel .stat-label {
@@ -2740,6 +2745,11 @@
         padding: 2px 0;
       }
 
+      #run-sampling-controls > summary {
+        border-top: none;
+        padding-top: 2px;
+      }
+
       details.mobile-advanced > summary::after {
         content: '+';
         font-family: var(--demo-label-family);
@@ -2785,11 +2795,11 @@
         min-width: 0;
       }
 
-      /* Small screens: lead with the primary text/output stack, then controls, then rail */
+      /* Small screens: lead with controls for text modes, then output, then rail */
       #app[data-mode="run"] .panel-stack-controls,
       #app[data-mode="translate"] .panel-stack-controls,
       #app[data-mode="embedding"] .panel-stack-controls {
-        order: 2;
+        order: 1;
         grid-column: 1 / -1;
       }
 
@@ -2802,7 +2812,7 @@
       #app[data-mode="run"] .panel-stack-primary,
       #app[data-mode="translate"] .panel-stack-primary,
       #app[data-mode="embedding"] .panel-stack-primary {
-        order: 1;
+        order: 2;
         grid-column: 1 / -1;
       }
 

--- a/demo/ui/styles/main.css
+++ b/demo/ui/styles/main.css
@@ -28,6 +28,7 @@
       flex-direction: column;
       min-height: 100vh;
       --panel-side-width: 300px;
+      --panel-rail-width: 268px;
       --doppler-signal: #ff6b35;
       --doppler-signal-soft: color-mix(in srgb, var(--doppler-signal) 14%, transparent);
       --doppler-glow: #f6b74f;
@@ -456,7 +457,8 @@
     #app[data-mode="embedding"] .panel-grid,
     #app[data-mode="diffusion"] .panel-grid,
     #app[data-mode="energy"] .panel-grid {
-      grid-template-columns: minmax(0, var(--panel-side-width)) minmax(0, 1fr) minmax(0, var(--panel-side-width));
+      grid-template-columns: minmax(0, var(--panel-side-width)) minmax(0, 1fr) minmax(0, var(--panel-rail-width));
+      align-items: stretch;
     }
 
     #app[data-mode="run"] .panel-stack-controls,
@@ -557,14 +559,109 @@
       min-width: 0;
     }
 
+    #app[data-mode="run"] .run-panel .playground-output,
+    #app[data-mode="translate"] .run-panel .playground-output,
+    #app[data-mode="embedding"] .run-panel .playground-output {
+      flex: 1 1 auto;
+      min-height: 0;
+      gap: 6px;
+    }
+
     .model-empty-notice {
-      display: flex;
+      position: relative;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
       align-items: center;
-      justify-content: space-between;
+      gap: var(--space-md);
+      padding: 14px 16px 14px 18px;
+      border: var(--border-sm) solid color-mix(in srgb, var(--fg) 14%, var(--bg));
+      background:
+        linear-gradient(180deg, color-mix(in srgb, var(--bg-contrast) 88%, var(--bg) 12%), var(--bg));
+    }
+
+    .model-empty-notice::before {
+      content: '';
+      position: absolute;
+      top: -1px;
+      bottom: -1px;
+      left: -1px;
+      width: 4px;
+      background: linear-gradient(180deg, var(--doppler-glow), var(--doppler-signal));
+    }
+
+    .model-empty-notice-copy {
+      display: flex;
+      flex-direction: column;
+      gap: 3px;
+      min-width: 0;
+    }
+
+    .model-empty-notice-kicker {
+      font-family: var(--demo-label-family);
+      font-size: 9px;
+      font-weight: var(--demo-label-weight);
+      line-height: 1.2;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: color-mix(in srgb, var(--doppler-signal) 74%, var(--fg));
+    }
+
+    .model-empty-notice-title {
+      font-family: var(--font-a);
+      font-size: 14px;
+      font-weight: 600;
+      line-height: 1.25;
+      letter-spacing: 0.01em;
+      text-transform: none;
+      max-width: 34ch;
+      white-space: nowrap;
+    }
+
+    .model-empty-notice-detail {
+      max-width: 48ch;
+      font-family: var(--font-b);
+      font-size: 12px;
+      line-height: 1.45;
+      color: color-mix(in srgb, var(--fg) 90%, transparent);
+      text-wrap: balance;
+    }
+
+    .model-empty-notice-action {
+      flex: 0 0 auto;
+      min-height: 30px;
+      padding: 4px 12px;
+      border-color: color-mix(in srgb, var(--fg) 26%, var(--bg));
+      background: color-mix(in srgb, var(--bg-contrast) 70%, var(--bg) 30%);
+      white-space: nowrap;
+    }
+
+    .run-controls-panel .model-empty-notice {
+      grid-template-columns: minmax(0, 1fr);
+      align-items: flex-start;
       gap: var(--space-sm);
-      padding: var(--space-sm);
-      border: var(--border-md) dashed var(--fg);
-      background: var(--bg-contrast);
+      margin-bottom: var(--space-xs);
+    }
+
+    .run-controls-panel .model-empty-notice-title {
+      max-width: none;
+      white-space: normal;
+    }
+
+    .run-controls-panel .model-empty-notice-detail {
+      max-width: none;
+    }
+
+    .run-controls-panel .model-empty-notice-action {
+      justify-self: start;
+    }
+
+    #app[data-mode="run"] .run-controls-panel,
+    #app[data-mode="run"] .run-panel,
+    #app[data-mode="translate"] .run-controls-panel,
+    #app[data-mode="translate"] .run-panel,
+    #app[data-mode="embedding"] .run-controls-panel,
+    #app[data-mode="embedding"] .run-panel {
+      height: 100%;
     }
 
     .quick-models {
@@ -696,6 +793,12 @@
       min-height: 0;
     }
 
+    #app[data-mode="run"] .run-panel .primary-stack,
+    #app[data-mode="translate"] .run-panel .primary-stack,
+    #app[data-mode="embedding"] .run-panel .primary-stack {
+      flex: 1 1 auto;
+    }
+
     .playground-field {
       display: flex;
       flex-direction: column;
@@ -729,6 +832,20 @@
       display: flex;
       flex-wrap: wrap;
       gap: var(--space-sm);
+    }
+
+    .run-controls-panel .playground-actions {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: var(--space-sm);
+    }
+
+    .run-controls-panel .playground-actions .btn {
+      width: 100%;
+    }
+
+    .run-controls-panel #run-stop-btn {
+      grid-column: 1 / -1;
     }
 
     .embedding-doc-list {
@@ -1375,6 +1492,20 @@
       overflow: visible;
     }
 
+    #app[data-mode="run"] #run-output,
+    #app[data-mode="translate"] #run-output,
+    #app[data-mode="embedding"] #run-output {
+      flex: 1 1 auto;
+      min-height: 360px;
+    }
+
+    #run-output-status {
+      padding-top: 6px;
+      border-top: var(--border-sm) dotted color-mix(in srgb, var(--fg) 26%, transparent);
+      color: color-mix(in srgb, var(--fg) 74%, transparent);
+      line-height: 1.2;
+    }
+
     .playground-output-canvas {
       width: 100%;
       height: auto;
@@ -2000,6 +2131,7 @@
       align-items: center;
       justify-content: space-between;
       gap: var(--space-sm);
+      margin-bottom: 2px;
     }
 
     .live-panel .pulse-header .type-label {
@@ -2012,6 +2144,22 @@
 
     .keyvalue-panel .pulse-section {
       gap: var(--space-xs);
+    }
+
+    .live-panel {
+      gap: 10px;
+    }
+
+    .live-panel .panel-subsection {
+      gap: 6px;
+    }
+
+    .live-panel .stats-grid {
+      gap: 4px var(--space-sm);
+    }
+
+    .live-panel .run-log {
+      gap: 4px;
     }
 
     .keyvalue-panel .pulse-subheader {
@@ -2427,7 +2575,7 @@
       }
     }
 
-@media (max-width: 777px) {
+@media (max-width: 1024px) {
   .page-shell {
     padding: var(--space-md) var(--space-sm);
   }
@@ -2571,10 +2719,14 @@
         min-width: 0;
       }
 
-      /* Mobile: left col → top, center → middle, right → bottom */
+      /* Small screens: lead with the primary text/output stack, then controls, then rail */
       #app[data-mode="run"] .panel-stack-controls,
       #app[data-mode="translate"] .panel-stack-controls,
-      #app[data-mode="embedding"] .panel-stack-controls,
+      #app[data-mode="embedding"] .panel-stack-controls {
+        order: 2;
+        grid-column: 1 / -1;
+      }
+
       #app[data-mode="diffusion"] .panel-stack-controls,
       #app[data-mode="energy"] .panel-stack-controls {
         order: 1;
@@ -2583,7 +2735,11 @@
 
       #app[data-mode="run"] .panel-stack-primary,
       #app[data-mode="translate"] .panel-stack-primary,
-      #app[data-mode="embedding"] .panel-stack-primary,
+      #app[data-mode="embedding"] .panel-stack-primary {
+        order: 1;
+        grid-column: 1 / -1;
+      }
+
       #app[data-mode="diffusion"] .panel-stack-primary,
       #app[data-mode="energy"] .panel-stack-primary,
       #app[data-mode="diagnostics"] .panel-stack-primary,
@@ -2625,6 +2781,19 @@
       .translate-lane-status-row {
         flex-direction: column;
         align-items: stretch;
+      }
+
+      .model-empty-notice {
+        grid-template-columns: minmax(0, 1fr);
+        align-items: flex-start;
+      }
+
+      .model-empty-notice-title {
+        white-space: normal;
+      }
+
+      .model-empty-notice-action {
+        justify-self: start;
       }
 
       .translate-proof-strip,
@@ -2701,7 +2870,7 @@
       }
     }
 
-    @media (min-width: 778px) {
+    @media (min-width: 1025px) {
       .page-shell {
         padding: var(--space-lg) var(--space-md);
       }


### PR DESCRIPTION
## Summary

This PR polishes the text-mode layout in the Doppler demo.

It improves the first-run setup experience, refines the controls and output hierarchy, tightens the right-rail telemetry presentation, and cleans up small-screen behavior so the flow feels more intentional across desktop, tablet, and mobile.

## What Changed

- moved the empty-state setup banner into the `Run Controls` panel above the prompt
- refined the banner copy, CTA labeling, spacing, and responsive behavior
- made the controls rail calmer by collapsing `Generation settings` by default on desktop
- improved spacing and alignment in `Generation settings`, including the reset-context checkbox row
- made `Generate` and `Clear` fill the controls width evenly
- fixed the running-state button layout so `Stop` replaces `Generate` cleanly instead of creating an awkward stacked row
- made the center `Text Generation` output area feel more like the primary canvas
- tightened the `Inference Pulse` rail and rebalanced the `Recent Runs` columns to avoid label overlap
- updated small-screen ordering so `Run Controls` appears before `Text Generation`
- adjusted runtime panel-stack insertion so the live DOM and heading order better match the actual task flow
- removed extra divider noise, including the duplicate mobile line above `Generation settings` and the output-status separator

**BEFORE**
<img width="1497" height="755" alt="Screenshot 2026-03-17 at 2 59 25 PM" src="https://github.com/user-attachments/assets/b5e0a919-7e7b-470f-82c6-79ae3528459a" />

**AFTER**
<img width="1842" height="960" alt="Screenshot 2026-03-17 at 2 59 18 PM" src="https://github.com/user-attachments/assets/cc0d3077-131e-432a-b256-f94fa6066571" />

## Files Touched

- `demo/demo.js`
- `demo/index.html`
- `demo/ui/styles/main.css`

## Testing Instructions

1. Start the local static server from the Doppler repo root:

   ```bash
   cd /Users/haileyrobledo/Git/deco/doppler
   python3 -m http.server 8080
   ```

2. Open the demo in the browser:
   - `http://localhost:8080/demo/`

3. Open the `Text` mode with:
   - no compatible text model imported
   - a compatible text model imported

4. Verify the empty/setup state:
   - the setup banner appears inside `Run Controls`
   - the banner copy and CTA feel clear and readable
   - the prompt remains visually primary within the left rail

5. Verify the controls behavior:
   - `Generation settings` is collapsed by default on desktop
   - spacing/alignment inside `Generation settings` is consistent
   - `Generate` and `Clear` share the full width evenly
   - when a run starts, `Stop` and `Clear` lay out cleanly with no awkward stacking

6. Verify the output and telemetry layout:
   - the center output area feels dominant and has a taller main canvas
   - the output status sits cleanly below the box without an extra divider line
   - `Inference Pulse` feels tighter and `Recent Runs` labels do not overlap

7. Check the experience at:
   - desktop width
   - tablet width
   - phone width

8. On tablet and phone widths, verify:
   - `Run Controls` appears above `Text Generation`
   - `Generation settings` shows only one divider above its heading
